### PR TITLE
Fix: add UUID to S3 key to prevent collision — Issue #3

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,6 @@
 
+import { randomUUID } from "crypto";
+
 export const generateS3Key = (timestamp: number): string => {
-    return `screenshots/${timestamp}.png`;
+    return `screenshots/${timestamp}-${randomUUID()}.png`;
 };


### PR DESCRIPTION
## Summary
- Append `crypto.randomUUID()` to S3 key to prevent timestamp collisions
- `generateS3Key()` now returns `screenshots/${timestamp}-${uuid}.png`
- No new dependencies — uses Node.js built-in `crypto.randomUUID()`

## Why this matters
The original `screenshots/${timestamp}.png` key collides when two screenshot requests happen in the same millisecond, causing one to overwrite the other in S3.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Concurrent screenshot requests produce unique S3 keys
- [ ] Images stored match database records

## Related issue
Fixes #3