### PR TITLE
Fix: add overall request timeout to screenshot endpoint — Issue #4

### DIFF
--- a/src/config/puppeteer.ts
+++ b/src/config/puppeteer.ts
@@ -1,3 +1,5 @@
+export const REQUEST_TIMEOUT_MS = 90000;
+
 export const PUPPETEER_LAUNCH_OPTIONS = {
 
     headless: true,

--- a/src/routes/screenshot.ts
+++ b/src/routes/screenshot.ts
@@ -5,6 +5,7 @@ import { errorResponse } from "../utils/response";
 import { uploadScreenshot } from "../services/uploader";
 import { recordScreenshot } from "../services/recorder";
 import { getAuth } from "@clerk/express";
+import { REQUEST_TIMEOUT_MS } from "../config/puppeteer";
 
 const router = Router();
 
@@ -22,30 +23,40 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
 
     const {url,width,height,fullPage,userAgent,authorizationHeader,cookies} = validation.data;
     try {
-        const buffer = await takeScreenshot({
-            url,
-            fullPage: fullPage,
-            width: width,
-            height: height,
-            userAgent: userAgent,
-            authorizationHeader: authorizationHeader,
-            cookies: cookies,
-        });
-        
-        const upload = await uploadScreenshot(buffer);
+        const screenshotFlow = async () => {
+            const buffer = await takeScreenshot({
+                url,
+                fullPage: fullPage,
+                width: width,
+                height: height,
+                userAgent: userAgent,
+                authorizationHeader: authorizationHeader,
+                cookies: cookies,
+            });
 
-        const record = await recordScreenshot({
-            target_url: url,
-            user_id: userId ?? "",
-            width: width ?? 1280,
-            height: height ?? 800,
-            full_page: fullPage ?? true,
-            s3_key: upload.s3_key,
-            s3_url: upload.s3_url,
-            user_agent: userAgent,
-            authorization_header: authorizationHeader,
-            cookies_used: !!cookies,
+            const upload = await uploadScreenshot(buffer);
+
+            const record = await recordScreenshot({
+                target_url: url,
+                user_id: userId ?? "",
+                width: width ?? 1280,
+                height: height ?? 800,
+                full_page: fullPage ?? true,
+                s3_key: upload.s3_key,
+                s3_url: upload.s3_url,
+                user_agent: userAgent,
+                authorization_header: authorizationHeader,
+                cookies_used: !!cookies,
+            });
+
+            return record;
+        };
+
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("Request timeout exceeded")), REQUEST_TIMEOUT_MS);
         });
+
+        const record = await Promise.race([screenshotFlow(), timeoutPromise]);
 
         res.status(201).json({
             success: true,


### PR DESCRIPTION
## Summary
- Wrap the screenshot flow in `Promise.race` with a 90s timeout
- Add `REQUEST_TIMEOUT_MS = 90000` to `src/config/puppeteer.ts`
- If request exceeds timeout, returns 500 with "Failed to take screenshot"

## Why this matters
Without an overall timeout, a hanging Puppeteer request (e.g., target page never resolves) could hang indefinitely, exhausting server connections.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Normal screenshot requests complete successfully
- [ ] Timeout triggers at ~90s for hanging requests

## Related issue
Fixes #4