### PR TITLE
Fix: add retry logic with exponential backoff for transient failures — Issue #5

### DIFF
--- a/src/routes/screenshot.ts
+++ b/src/routes/screenshot.ts
@@ -5,6 +5,7 @@ import { errorResponse } from "../utils/response";
 import { uploadScreenshot } from "../services/uploader";
 import { recordScreenshot } from "../services/recorder";
 import { getAuth } from "@clerk/express";
+import { withRetry } from "../utils/retry";
 
 const router = Router();
 
@@ -22,17 +23,19 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
 
     const {url,width,height,fullPage,userAgent,authorizationHeader,cookies} = validation.data;
     try {
-        const buffer = await takeScreenshot({
-            url,
-            fullPage: fullPage,
-            width: width,
-            height: height,
-            userAgent: userAgent,
-            authorizationHeader: authorizationHeader,
-            cookies: cookies,
-        });
-        
-        const upload = await uploadScreenshot(buffer);
+        const buffer = await withRetry(() =>
+            takeScreenshot({
+                url,
+                fullPage: fullPage,
+                width: width,
+                height: height,
+                userAgent: userAgent,
+                authorizationHeader: authorizationHeader,
+                cookies: cookies,
+            })
+        );
+
+        const upload = await withRetry(() => uploadScreenshot(buffer));
 
         const record = await recordScreenshot({
             target_url: url,

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,27 @@
+export interface RetryOptions {
+    maxAttempts?: number;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+}
+
+export async function withRetry<T>(
+    fn: () => Promise<T>,
+    options: RetryOptions = {}
+): Promise<T> {
+    const { maxAttempts = 3, initialDelayMs = 1000, maxDelayMs = 8000 } = options;
+
+    let attempt = 0;
+    let delay = initialDelayMs;
+
+    while (true) {
+        try {
+            return await fn();
+        } catch (error) {
+            attempt++;
+            if (attempt >= maxAttempts) throw error;
+
+            await new Promise(resolve => setTimeout(resolve, delay));
+            delay = Math.min(delay * 2, maxDelayMs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `withRetry()` utility in `src/utils/retry.ts` with configurable attempts and exponential backoff
- Wrap `takeScreenshot()` and `uploadScreenshot()` calls with `withRetry()`
- Default: 3 attempts, 1s initial delay, doubling each attempt, max 8s delay

## Why this matters
Transient failures (network hiccup, S3 throttling, Chrome crash) currently fail immediately with no retry, degrading reliability for users.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Normal requests succeed without visible retry overhead
- [ ] Simulate failure — verify retries occur and eventually fail after 3 attempts

## Related issue
Fixes #5