### PR TITLE
Fix: differentiate error responses by failure type — Issue #6

### DIFF
--- a/src/routes/screenshot.ts
+++ b/src/routes/screenshot.ts
@@ -1,10 +1,10 @@
 import { Router, Request, Response } from "express";
 import { takeScreenshot } from "../services/screenshotter";
 import { validateScreenshotOptions } from "../validators/screenshot-validator";
-import { errorResponse } from "../utils/response";
 import { uploadScreenshot } from "../services/uploader";
 import { recordScreenshot } from "../services/recorder";
 import { getAuth } from "@clerk/express";
+import { ScreenshotError, S3UploadError } from "../utils/errors";
 
 const router = Router();
 
@@ -14,9 +14,7 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
     const validation = validateScreenshotOptions(req.body);
 
     if(!validation.valid || !validation.data) {
-        const err = errorResponse(validation.error || "Invalid request body", 400);
-
-        res.status(400).json(err.body);
+        res.status(400).json({ error: validation.error || "Invalid request body" });
         return;
     }
 
@@ -54,11 +52,15 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
         });
 
     } catch (error) {
-        console.error("Screenshot attempt failed:");
-        console.error(error);
+        console.error("Screenshot attempt failed:", error);
 
-        const err = errorResponse("Failed to take screenshot", 500);
-        res.status(500).json(err.body);
+        if (error instanceof ScreenshotError) {
+            res.status(502).json({ error: "Screenshot service unavailable", code: error.code });
+        } else if (error instanceof S3UploadError) {
+            res.status(502).json({ error: "Storage service unavailable", code: error.code });
+        } else {
+            res.status(500).json({ error: "Internal server error" });
+        }
     }
 });
 

--- a/src/services/screenshotter.ts
+++ b/src/services/screenshotter.ts
@@ -2,6 +2,7 @@ import puppeteer, { Browser } from "puppeteer";
 import { PUPPETEER_LAUNCH_OPTIONS, DEFAULT_VIEWPORT, DEFAULT_TIMEOUT } from "../config/puppeteer";
 import { ScreenshotOptions } from "../types";
 import { parseCookies } from "../utils/parseCookies";
+import { ScreenshotError } from "../utils/errors";
 
 
 export async function takeScreenshot(options: ScreenshotOptions): Promise<Buffer> {
@@ -18,7 +19,7 @@ export async function takeScreenshot(options: ScreenshotOptions): Promise<Buffer
     let browser: Browser | undefined;
 
     try {
-        browser = await puppeteer.launch(PUPPETEER_LAUNCH_OPTIONS); 
+        browser = await puppeteer.launch(PUPPETEER_LAUNCH_OPTIONS);
 
         const page = await browser.newPage();
 
@@ -51,6 +52,11 @@ export async function takeScreenshot(options: ScreenshotOptions): Promise<Buffer
         })
 
         return Buffer.from(screenshot);
+    } catch (error) {
+        throw new ScreenshotError(
+            "Screenshot capture failed" + (error instanceof Error ? `: ${error.message}` : ""),
+            "SCREENSHOT_FAILED"
+        );
     } finally {
         if (browser) {
             await browser.close();

--- a/src/services/uploader.ts
+++ b/src/services/uploader.ts
@@ -3,6 +3,7 @@ import { s3Client } from "../config/s3";
 import { AWS_S3_BUCKET, AWS_REGION } from "../config/env";
 import { UploadResult } from "../types";
 import { generateS3Key } from "../utils/storage";
+import { S3UploadError } from "../utils/errors";
 
 export const uploadScreenshot = async (buffer: Buffer): Promise<UploadResult> => {
     const timestamp = Date.now();
@@ -26,6 +27,9 @@ export const uploadScreenshot = async (buffer: Buffer): Promise<UploadResult> =>
         };        
     } catch (error) {
         console.error("[uploader] S3 upload failed:", error);
-        throw error;
+        throw new S3UploadError(
+            "S3 upload failed" + (error instanceof Error ? `: ${error.message}` : ""),
+            "S3_UPLOAD_FAILED"
+        );
     }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,20 @@
+export class ScreenshotError extends Error {
+    constructor(message: string, public readonly code: string) {
+        super(message);
+        this.name = "ScreenshotError";
+    }
+}
+
+export class S3UploadError extends Error {
+    constructor(message: string, public readonly code: string) {
+        super(message);
+        this.name = "S3UploadError";
+    }
+}
+
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ValidationError";
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScreenshotError` and `S3UploadError` classes in `src/utils/errors.ts`
- `takeScreenshot()` throws `ScreenshotError` on failure
- `uploadScreenshot()` throws `S3UploadError` on failure
- Route catch block now differentiates:
  - ScreenshotError → 502 "Screenshot service unavailable"
  - S3UploadError → 502 "Storage service unavailable"
  - Unknown → 500 "Internal server error"

## Why this matters
Previously all errors returned the same generic message, making debugging difficult and user-facing errors unclear.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Invalid URL → 400 with clear message
- [ ] Screenshot failure → 502 with code "SCREENSHOT_FAILED"
- [ ] S3 failure → 502 with code "S3_UPLOAD_FAILED"
- [ ] Unknown error → 500 "Internal server error"

## Related issue
Fixes #6