### PR TITLE
Fix: add rate limiting to screenshot endpoint — Issue #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.4.1",
         "puppeteer": "^24.38.0"
       },
       "devDependencies": {
@@ -2836,6 +2837,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extract-zip": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.4.1",
     "puppeteer": "^24.38.0"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,20 @@
 import express from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import screenshotRouter from "./routes/screenshot";
 import { clerkMiddleware } from "@clerk/express";
+
+const screenshotLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 10,
+    keyGenerator: (req) => {
+        // @ts-expect-error - clerk adds auth to request
+        return req.auth?.userId ?? req.ip;
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: "Too many requests, please try again later" }
+});
 
 const app = express();
 
@@ -13,6 +26,6 @@ app.get("/health", (_req, res) => {
     res.json({ status: "ok" });
 })
 
-app.use("/screenshot", screenshotRouter);
+app.use("/screenshot", screenshotLimiter, screenshotRouter);
 
 export default app;


### PR DESCRIPTION
## Summary
- Add `express-rate-limit` middleware to `/screenshot` route
- 10 requests per minute per userId (falls back to IP for unauthenticated requests)
- Returns 429 with `{ error: "Too many requests, please try again later" }` when exceeded

## Why this matters
Without rate limiting, a malicious or careless user could spam the endpoint, spawning many Puppeteer instances and exhausting server resources (CPU, memory, network, S3 costs).

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Send 11 requests in a minute — 12th should return 429
- [ ] Normal requests succeed within the 10/min limit

## Related issue
Fixes #7