### PR TITLE
Fix: add security headers with helmet middleware — Issue #8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "helmet": "^8.1.0",
         "puppeteer": "^24.38.0"
       },
       "devDependencies": {
@@ -3127,6 +3128,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "helmet": "^8.1.0",
     "puppeteer": "^24.38.0"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,12 @@
 import express from "express";
 import cors from "cors";
+import helmet from "helmet";
 import screenshotRouter from "./routes/screenshot";
 import { clerkMiddleware } from "@clerk/express";
 
 const app = express();
 
+app.use(helmet());
 app.use(cors());
 app.use(express.json());
 app.use(clerkMiddleware());


### PR DESCRIPTION
## Summary
- Add `helmet()` middleware to Express app
- Sets security headers: `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, and more
- Applied before other middleware for maximum coverage

## Why this matters
Without security headers, the API is more vulnerable to XSS, clickjacking, and MIME-type sniffing attacks.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] `curl -I http://localhost:3001/health` shows security headers

## Related issue
Fixes #8